### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   crus:
     build:


### PR DESCRIPTION
docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion